### PR TITLE
rename Cloud Container Builder to Cloud Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pipeline
 
-The pipeline tutorial walks you through creating an end-to-end deployment pipeline using [Cloud Container Builder](https://cloud.google.com/container-builder), [GitHub](https://github.com), and multiple [Kubernetes](https://cloud.google.com/kubernetes-engine) clusters.
+The pipeline tutorial walks you through creating an end-to-end deployment pipeline using [Cloud Build](https://cloud.google.com/cloud-build), [GitHub](https://github.com), and multiple [Kubernetes](https://cloud.google.com/kubernetes-engine) clusters.
 
 This tutorial will demonstrate how to propagate a Kubernetes deployment through multiple environments, each backed by a dedicated Kubernetes cluster, using a collection of Kubernetes manifest files across a set of GitHub repositories representing each environment.
 
@@ -24,7 +24,7 @@ This tutorial will set up a pipeline to deploy the [pipeline application](https:
 * [Provision the Kubernetes Clusters](labs/kubernetes-clusters.md)
 * [Create a Hub Configuration File](labs/hub-configuration-file.md)
 * [Setup the GitHub Repositories](labs/github-repositories.md)
-* [Create the Container Builder Build Triggers](labs/build-triggers.md)
+* [Create the Cloud Build Build Triggers](labs/build-triggers.md)
 * [Test the Build Pipeline](labs/test-the-pipeline.md)
 
 ## Cleanup

--- a/labs/build-triggers.md
+++ b/labs/build-triggers.md
@@ -1,6 +1,6 @@
-# Container Builder Build Triggers
+# Cloud Build Triggers
 
-In this section you will create the [Container Builder](https://cloud.google.com/container-builder) build triggers necessary to establish an [end-to-end build pipeline](deployment-pipeline.md).
+In this section you will create the [Cloud Build](https://cloud.google.com/cloud-build) build triggers necessary to establish an [end-to-end build pipeline](deployment-pipeline.md).
 
 ![Image of GCP Build Triggers UI](images/build-triggers-empty.png)
 
@@ -14,9 +14,9 @@ gcloud auth application-default login
 
 Ensure you have a default zone configured as describe in the [prerequisites lab](labs/prerequisites.md)
 
-## Generate Container Builder Build Trigger Configurations
+## Generate Cloud Build Trigger Configurations
 
-In this section you will generate the build trigger configuration payloads that will be used to automated the creation of the Container Builder build triggers hosted on GCP.
+In this section you will generate the build trigger configuration payloads that will be used to automated the creation of the Cloud Build triggers hosted on GCP.
 
 Retrieve the default compute zone and store it in the `COMPUTE_ZONE` env var:
 
@@ -143,9 +143,9 @@ cat <<EOF > pipeline-production-deployment-trigger.json
 EOF
 ```
 
-## Create the Container Build Triggers
+## Create the Cloud Build Triggers
 
-In this section you will create the Cloud Builder build triggers by submitting the build trigger configuration files generated in the previous section using the GCP API.
+In this section you will create the Cloud Build triggers by submitting the build trigger configuration files generated in the previous section using the GCP API.
 
 Create a cloud build trigger for each build trigger configuration file:
 

--- a/labs/deployment-pipeline.md
+++ b/labs/deployment-pipeline.md
@@ -1,8 +1,8 @@
 # The Deployment Pipeline
 
-The heavy lifting of the deployment pipeline is done by [Cloud Container Builder](https://cloud.google.com/container-builder/) and [Kubernetes](https://cloud.google.com/kubernetes-engine).
+The heavy lifting of the deployment pipeline is done by [Cloud Build](https://cloud.google.com/cloud-build) and [Kubernetes](https://cloud.google.com/kubernetes-engine).
 
-Take a moment to study the Container Builder build requests files (cloudbuild.yaml) across the various GitHub repositories to get a sense of how the pipeline fits together:
+Take a moment to study the Cloud Build requests files (cloudbuild.yaml) across the various GitHub repositories to get a sense of how the pipeline fits together:
 
 * [pipeline-application](https://github.com/kelseyhightower/pipeline-application)
 * [pipeline-infrastructure-staging](https://github.com/kelseyhightower/pipeline-infrastructure-staging)

--- a/labs/github-repositories.md
+++ b/labs/github-repositories.md
@@ -1,6 +1,6 @@
 # Setup the GitHub Repositories
 
-In this section you will create a set of GitHub repositories which hold the Cloud Builder [build requests](https://cloud.google.com/container-builder/docs/concepts/build-requests) and the pipeline application code, a set of [Cloud Source Repositories](https://cloud.google.com/source-repositories) to mirror them to your GCP project, and provision a GitHub webhook to keep them synchronized.
+In this section you will create a set of GitHub repositories which hold the Cloud Builder [build requests](https://cloud.google.com/cloud-build/docs/build-config) and the pipeline application code, a set of [Cloud Source Repositories](https://cloud.google.com/source-repositories) to mirror them to your GCP project, and provision a GitHub webhook to keep them synchronized.
 
 ## Fork the Pipeline Application and Infrastructure Repositories
 
@@ -40,7 +40,7 @@ At this point the pipeline application and infrastructure repositories have been
 
 ## Mirror GitHub Repositories to Cloud Source Repositories
 
-Currently Container Builder only supports build triggers on [Cloud Source Repositories](https://cloud.google.com/source-repositories)(CSR). In this section you will create the Cloud Source Repositories that will mirror each of the GitHub repositories created in the previous section.
+Currently Cloud Build only supports build triggers on [Cloud Source Repositories](https://cloud.google.com/source-repositories)(CSR). In this section you will create the Cloud Source Repositories that will mirror each of the GitHub repositories created in the previous section.
 
 Set the list of repository names:
 
@@ -150,4 +150,4 @@ done
 
 Each GitHub repositories is now set to send push events to the `reposync` webhook.
 
-Next: [Container Builder Build Triggers](build-triggers.md)
+Next: [Cloud Build Triggers](build-triggers.md)

--- a/labs/hub-configuration-file.md
+++ b/labs/hub-configuration-file.md
@@ -23,7 +23,7 @@ HUB_CONFIG="${PWD}/hub"
 
 ## Encrypt the Hub Configuration File and Upload to Google Cloud Storage
 
-In this section you will encrypt the hub configuration file using the [Google Key Management Service](https://cloud.google.com/kms) (KMS) and upload the encrypted file to a [Google Cloud Storage](https://cloud.google.com/storage) (GCS) bucket. Preforming these tasks will make the hub configuration file securely available to any automated build steps performed by Container Builder.
+In this section you will encrypt the hub configuration file using the [Google Key Management Service](https://cloud.google.com/kms) (KMS) and upload the encrypted file to a [Google Cloud Storage](https://cloud.google.com/storage) (GCS) bucket. Preforming these tasks will make the hub configuration file securely available to any automated build steps performed by Cloud Build.
 
 ### Create a KMS Keyring and Encryption Key
 
@@ -79,9 +79,9 @@ Upload the encrypted hub configuration file to the pipeline configs GCS bucket:
 gsutil cp hub.enc gs://${PROJECT_ID}-pipeline-configs/
 ```
 
-### Grant the Container Builder Service Account Access to the GitHub Encryption Key
+### Grant the Cloud Build Service Account Access to the GitHub Encryption Key
 
-In this section you will grant access to the `github` encrypt key to the Container Builder service account. Performing these steps will enable Container Builder to decrypt the hub configuration file during any automated build.
+In this section you will grant access to the `github` encrypt key to the Cloud Build service account. Performing these steps will enable Cloud Build to decrypt the hub configuration file during any automated build.
 
 Retrieve the active GCP project number and store it in the `PROJECT_NUMBER` env var:
 
@@ -89,7 +89,7 @@ Retrieve the active GCP project number and store it in the `PROJECT_NUMBER` env 
 PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')
 ```
 
-Grant the Container Builder service account access to the `github` encryption key:
+Grant the Cloud Build service account access to the `github` encryption key:
 
 ```
 gcloud kms keys add-iam-policy-binding github \

--- a/labs/kubernetes-clusters.md
+++ b/labs/kubernetes-clusters.md
@@ -40,9 +40,9 @@ qa          us-west1-c  1.7.8-gke.0     XX.XXX.XX.XX   n1-standard-1  1.7.8-gke.
 staging     us-west1-c  1.7.8-gke.0     XX.XXX.XXX.XX  n1-standard-1  1.7.8-gke.0   1          RUNNING
 ```
 
-## Grant the Container Builder Service Account access to the Google Kubernetes Engine API
+## Grant the Cloud Build Service Account access to the Google Kubernetes Engine API
 
-The Container Builder service needs the ability to fetch GKE credentials and apply changes to each Kubernetes cluster. Grant the Container Builder service account developer access to the GKE API.
+The Cloud Build service needs the ability to fetch GKE credentials and apply changes to each Kubernetes cluster. Grant the Cloud Build service account developer access to the GKE API.
 
 ```
 PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')


### PR DESCRIPTION
It seems Cloud Container Builder have changed name to Cloud Build since this was written